### PR TITLE
[#12] [Backend] As a user, I can see the detail of a TIL

### DIFF
--- a/_posts/example-2.md
+++ b/_posts/example-2.md
@@ -8,7 +8,7 @@ author:
   avatar: '/assets/authors/hoang.jpeg'
 ogImage:
   url: '/assets/posts/example/cover.png'
-tags: 'tag1, tag2'
+tags: ['tag1', 'tag2']
 ---
 
 Example 2 post Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Praesent elementum facilisis leo vel fringilla est ullamcorper eget. At imperdiet dui accumsan sit amet nulla facilities morbi tempus. Praesent elementum facilisis leo vel fringilla. Congue mauris rhoncus aenean vel. Egestas sed tempus urna et pharetra pharetra massa massa ultricies.

--- a/_posts/example-2.md
+++ b/_posts/example-2.md
@@ -8,6 +8,7 @@ author:
   avatar: '/assets/authors/hoang.jpeg'
 ogImage:
   url: '/assets/posts/example/cover.png'
+tags: 'tag1, tag2'
 ---
 
 Example 2 post Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Praesent elementum facilisis leo vel fringilla est ullamcorper eget. At imperdiet dui accumsan sit amet nulla facilities morbi tempus. Praesent elementum facilisis leo vel fringilla. Congue mauris rhoncus aenean vel. Egestas sed tempus urna et pharetra pharetra massa massa ultricies.

--- a/_posts/example.md
+++ b/_posts/example.md
@@ -8,6 +8,7 @@ author:
   avatar: '/assets/authors/hoang.jpeg'
 ogImage:
   url: '/assets/posts/example/cover.png'
+tags: 'tag1, tag2'
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Praesent elementum facilisis leo vel fringilla est ullamcorper eget. At imperdiet dui accumsan sit amet nulla facilities morbi tempus. Praesent elementum facilisis leo vel fringilla. Congue mauris rhoncus aenean vel. Egestas sed tempus urna et pharetra pharetra massa massa ultricies.

--- a/_posts/example.md
+++ b/_posts/example.md
@@ -8,7 +8,7 @@ author:
   avatar: '/assets/authors/hoang.jpeg'
 ogImage:
   url: '/assets/posts/example/cover.png'
-tags: 'tag1, tag2'
+tags: ['tag1', 'tag2']
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Praesent elementum facilisis leo vel fringilla est ullamcorper eget. At imperdiet dui accumsan sit amet nulla facilities morbi tempus. Praesent elementum facilisis leo vel fringilla. Congue mauris rhoncus aenean vel. Egestas sed tempus urna et pharetra pharetra massa massa ultricies.

--- a/src/lib/post.ts
+++ b/src/lib/post.ts
@@ -27,7 +27,8 @@ type Field =
   | 'date'
   | 'coverImage'
   | 'ogImage'
-  | 'author';
+  | 'author'
+  | 'tags';
 
 const BASIC_FIELDS = [
   'title',

--- a/src/lib/post.ts
+++ b/src/lib/post.ts
@@ -17,6 +17,7 @@ type Post = {
   coverImage: string;
   ogImage: string;
   author: Author;
+  tags: string[];
 };
 
 type Field =
@@ -38,6 +39,8 @@ const BASIC_FIELDS = [
   'coverImage',
   'excerpt',
 ] as Field[];
+
+const EXTENDED_FIELDS = [...BASIC_FIELDS, 'content', 'tags'] as Field[];
 
 const SLUG_EXTENSION = /\.md$/;
 
@@ -88,5 +91,5 @@ const getAllPosts = (fields: Field[] = []): Post[] => {
   return posts;
 };
 
-export { getPostBySlug, getAllPosts, BASIC_FIELDS };
+export { getPostBySlug, getAllPosts, BASIC_FIELDS, EXTENDED_FIELDS };
 export type { Post, Field };

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -1,5 +1,6 @@
 import { ReactElement } from 'react';
 
+import { GetStaticProps } from 'next';
 import Head from 'next/head';
 
 import Layout from 'components/Layout';
@@ -39,7 +40,7 @@ Home.getLayout = (page: ReactElement) => <Layout>{page}</Layout>;
 
 export default Home;
 
-export const getStaticProps = async () => {
+export const getStaticProps: GetStaticProps = async () => {
   const posts = getAllPosts(BASIC_FIELDS);
   const { paginatedItems } = getPaginationData(posts, 1);
 

--- a/src/pages/posts/[slug].page.tsx
+++ b/src/pages/posts/[slug].page.tsx
@@ -58,8 +58,8 @@ export const getStaticPaths: GetStaticPaths = async () => {
   };
 };
 
-export const getStaticProps: GetStaticProps = async (context) => {
-  const { slug } = context.params as PostParams;
+export const getStaticProps: GetStaticProps = async ({ params }) => {
+  const { slug } = params as PostParams;
   const post = getPostBySlug(slug, BASIC_FIELDS);
 
   return {

--- a/src/pages/posts/[slug].page.tsx
+++ b/src/pages/posts/[slug].page.tsx
@@ -7,7 +7,13 @@ import Head from 'next/head';
 
 import Layout from 'components/Layout';
 import { getPageTitle } from 'helpers/pageTitle';
-import { BASIC_FIELDS, getAllPosts, getPostBySlug, Post } from 'lib/post';
+import {
+  BASIC_FIELDS,
+  EXTENDED_FIELDS,
+  getAllPosts,
+  getPostBySlug,
+  Post,
+} from 'lib/post';
 
 interface PostProps {
   post: Post;
@@ -60,7 +66,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
 
 export const getStaticProps: GetStaticProps = async ({ params }) => {
   const { slug } = params as PostParams;
-  const post = getPostBySlug(slug, BASIC_FIELDS);
+  const post = getPostBySlug(slug, EXTENDED_FIELDS);
 
   return {
     props: { post },

--- a/src/pages/posts/[slug].page.tsx
+++ b/src/pages/posts/[slug].page.tsx
@@ -1,0 +1,68 @@
+import { ParsedUrlQuery } from 'querystring';
+
+import { ReactElement } from 'react';
+
+import { GetStaticPaths, GetStaticProps } from 'next';
+import Head from 'next/head';
+
+import Layout from 'components/Layout';
+import { getPageTitle } from 'helpers/pageTitle';
+import { BASIC_FIELDS, getAllPosts, getPostBySlug, Post } from 'lib/post';
+
+interface PostProps {
+  post: Post;
+}
+
+interface PostParams extends ParsedUrlQuery {
+  slug: string;
+}
+
+export const postDetailsTestIds = {
+  title: 'post-details__title',
+};
+
+const PostDetails = ({ post }: PostProps) => {
+  return (
+    <>
+      <Head>
+        <title>{getPageTitle(post.title)}</title>
+      </Head>
+
+      <h1
+        className="m-8 text-7xl items-center text-center"
+        data-test-id={postDetailsTestIds.title}
+      >
+        {post.title}
+      </h1>
+    </>
+  );
+};
+
+PostDetails.getLayout = (page: ReactElement) => <Layout>{page}</Layout>;
+
+export default PostDetails;
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const posts = getAllPosts(BASIC_FIELDS);
+
+  // Get the paths we want to pre-render based on posts
+  const paths = posts.map((post) => ({
+    params: { slug: post.slug },
+  }));
+
+  // We'll pre-render only these paths at build time.
+  // { fallback: false } means other routes should 404.
+  return {
+    paths,
+    fallback: false,
+  };
+};
+
+export const getStaticProps: GetStaticProps = async (context) => {
+  const { slug } = context.params as PostParams;
+  const post = getPostBySlug(slug, BASIC_FIELDS);
+
+  return {
+    props: { post },
+  };
+};

--- a/src/pages/posts/[slug].test.tsx
+++ b/src/pages/posts/[slug].test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+
+import { BASIC_FIELDS, getAllPosts } from 'lib/post';
+
+import PostDetails, { postDetailsTestIds } from './[slug].page';
+
+describe('PostDetails', () => {
+  it('renders the title', () => {
+    const posts = getAllPosts(BASIC_FIELDS);
+    const post = posts[0];
+
+    render(<PostDetails post={post} />);
+
+    const title = screen.getByTestId(postDetailsTestIds.title);
+
+    expect(title).toBeVisible();
+    expect(title).toHaveTextContent(post.title);
+  });
+});


### PR DESCRIPTION
Closes https://github.com/nimblehq/til-web/issues/12

## What happened 👀

Add a new attribute `tags` to the  list of post attributes

## Insight 📝

The frontend part will be implemented in https://github.com/nimblehq/til-web/issues/21

This PR makes use of [getStaticPaths](https://nextjs.org/docs/api-reference/data-fetching/get-static-paths) in order to pre-render(for SEO) all the post paths

## Proof Of Work 📹

<img width="1481" alt="image" src="https://user-images.githubusercontent.com/39977805/172294256-9725f164-0a5b-4075-b240-06e55a1efbb1.png">