### PR TITLE
[#37] Add a helper to get GitHub avatar URL

### DIFF
--- a/_posts/example-2.md
+++ b/_posts/example-2.md
@@ -5,7 +5,7 @@ coverImage: '/til/assets/posts/example/cover.png'
 date: '2022-05-15T15:00:00+07:00'
 author:
   name: Hoang
-  avatar: '/til/assets/authors/hoang.jpeg'
+  avatarUrl: '/til/assets/authors/hoang.jpeg'
 ogImage:
   url: '/til/assets/posts/example/cover.png'
 tags: ['tag1', 'tag2']

--- a/_posts/example.md
+++ b/_posts/example.md
@@ -4,8 +4,8 @@ excerpt: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmo
 coverImage: '/til/assets/posts/example/cover.png'
 date: '2022-05-15T15:00:00+07:00'
 author:
+  username: hoangmirs
   name: Hoang
-  avatar: '/til/assets/authors/hoang.jpeg'
 ogImage:
   url: '/til/assets/posts/example/cover.png'
 tags: ['tag1', 'tag2']

--- a/next.config.js
+++ b/next.config.js
@@ -8,6 +8,7 @@ const nextConfig = {
   basePath: basePath,
   images: {
     path: `${basePath}/_next/image`,
+    domains: ['github.com'],
   },
   async redirects() {
     return [

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -1,8 +1,16 @@
 import NextImage, { ImageProps } from 'next/image';
 
+import { isValidUrl } from 'helpers/url';
+
 const Image = ({ src, children, ...rest }: ImageProps) => {
   const isProd = process.env.NODE_ENV === 'production';
-  const finalSrc = isProd ? src : `${process.env.NEXT_PUBLIC_BASE_PATH}${src}`;
+  let finalSrc;
+
+  if (typeof src === 'string' && isValidUrl(src)) {
+    finalSrc = src;
+  } else {
+    finalSrc = isProd ? src : `${process.env.NEXT_PUBLIC_BASE_PATH}${src}`;
+  }
 
   return (
     <NextImage src={finalSrc} {...rest}>

--- a/src/components/Post/Card.tsx
+++ b/src/components/Post/Card.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 
 import Image from 'components/Image';
 import TagList from 'components/Tag/List';
+import { getAuthorName, getAvatarUrl } from 'helpers/author';
 import { formatDate } from 'helpers/dateTime';
 import { Post } from 'lib/post';
 
@@ -65,8 +66,8 @@ const PostCard = ({ post, itemsRowWise = false }: PostCardProps) => {
           <div className="flex items-center gap-2">
             <div className="w-8 h-8">
               <Image
-                src={post.author.avatar}
-                alt={post.author.name}
+                src={getAvatarUrl(post.author, 32)}
+                alt={getAuthorName(post.author)}
                 width={32}
                 height={32}
                 className="rounded-full"
@@ -78,7 +79,7 @@ const PostCard = ({ post, itemsRowWise = false }: PostCardProps) => {
               className="text-sm font-semibold"
               data-test-id={postCardTestIds.authorName}
             >
-              {post.author.name}
+              {getAuthorName(post.author)}
             </div>
             <time
               className="text-sm"

--- a/src/components/Post/Details.tsx
+++ b/src/components/Post/Details.tsx
@@ -1,5 +1,6 @@
 import Image from 'components/Image';
 import TagList from 'components/Tag/List';
+import { getAuthorName, getAvatarUrl } from 'helpers/author';
 import { formatDate } from 'helpers/dateTime';
 import { Post } from 'lib/post';
 
@@ -51,8 +52,8 @@ const PostDetails = ({ post }: PostDetailsProps) => {
           <div className="flex items-center gap-2">
             <div className="w-8 h-8">
               <Image
-                src={post.author.avatar}
-                alt={post.author.name}
+                src={getAvatarUrl(post.author, 32)}
+                alt={getAuthorName(post.author)}
                 width={32}
                 height={32}
                 className="rounded-full"
@@ -64,7 +65,7 @@ const PostDetails = ({ post }: PostDetailsProps) => {
               className="text-sm font-semibold"
               data-test-id={postDetailsTestIds.authorName}
             >
-              {post.author.name}
+              {getAuthorName(post.author)}
             </div>
             <time
               className="text-sm"

--- a/src/helpers/author.test.ts
+++ b/src/helpers/author.test.ts
@@ -1,0 +1,103 @@
+import { Author } from 'lib/post';
+
+import { getAuthorName, getAvatarUrl } from './author';
+
+describe('Author helper', () => {
+  describe('getAvatarUrl', () => {
+    describe('when author has a username', () => {
+      it('returns the GitHub avatar URL', () => {
+        const username = 'james-d-kelly';
+        const author: Author = {
+          name: 'John Doe',
+          username,
+        };
+
+        const avatarUrl = getAvatarUrl(author);
+
+        expect(avatarUrl).toBe(
+          `https://github.com/${author.username}.png?size=128`
+        );
+      });
+    });
+
+    describe('when author has an avatar', () => {
+      it('returns the avatar URL', () => {
+        const imageUrl =
+          'https://avatars0.githubusercontent.com/u/12345?size=128';
+        const author: Author = {
+          name: 'John Doe',
+          avatarUrl: imageUrl,
+        };
+
+        const avatarUrl = getAvatarUrl(author);
+
+        expect(avatarUrl).toBe(imageUrl);
+      });
+    });
+
+    describe('when author has neither a username nor an avatar', () => {
+      it('returns an empty string', () => {
+        const author: Author = {
+          name: 'John Doe',
+        };
+
+        const avatarUrl = getAvatarUrl(author);
+
+        expect(avatarUrl).toBe('');
+      });
+    });
+  });
+
+  describe('getAuthorName', () => {
+    describe('when author has a name', () => {
+      it('returns the name', () => {
+        const name = 'John Doe';
+        const author: Author = {
+          name,
+        };
+
+        const authorName = getAuthorName(author);
+
+        expect(authorName).toBe(name);
+      });
+    });
+
+    describe('when author has a username', () => {
+      it('returns the username', () => {
+        const username = 'james-d-kelly';
+        const author: Author = {
+          username,
+        };
+
+        const authorName = getAuthorName(author);
+
+        expect(authorName).toBe(username);
+      });
+    });
+
+    describe('when author has neither a name nor a username', () => {
+      it('returns an empty string', () => {
+        const author: Author = {};
+
+        const authorName = getAuthorName(author);
+
+        expect(authorName).toBe('');
+      });
+    });
+
+    describe('when author has both a name and a username', () => {
+      it('returns the name', () => {
+        const name = 'John Doe';
+        const username = 'james-d-kelly';
+        const author: Author = {
+          name,
+          username,
+        };
+
+        const authorName = getAuthorName(author);
+
+        expect(authorName).toBe(name);
+      });
+    });
+  });
+});

--- a/src/helpers/author.ts
+++ b/src/helpers/author.ts
@@ -1,0 +1,23 @@
+import { Author } from 'lib/post';
+
+const getAvatarUrl = (author: Author, size = 128): string => {
+  if (author.username) {
+    return `https://github.com/${author.username}.png?size=${size}`;
+  }
+
+  return author.avatarUrl || '';
+};
+
+const getAuthorName = (author: Author): string => {
+  if (author.name) {
+    return author.name;
+  }
+
+  if (author.username) {
+    return author.username;
+  }
+
+  return '';
+};
+
+export { getAvatarUrl, getAuthorName };

--- a/src/helpers/url.test.ts
+++ b/src/helpers/url.test.ts
@@ -1,0 +1,25 @@
+import { isValidUrl } from './url';
+
+describe('URL helper', () => {
+  describe('isValidUrl', () => {
+    describe('when URL is valid', () => {
+      it('returns true', () => {
+        const url = 'https://example.com';
+
+        const isValid = isValidUrl(url);
+
+        expect(isValid).toBe(true);
+      });
+    });
+
+    describe('when URL is invalid', () => {
+      it('returns false', () => {
+        const url = 'invalid-url';
+
+        const isValid = isValidUrl(url);
+
+        expect(isValid).toBe(false);
+      });
+    });
+  });
+});

--- a/src/helpers/url.ts
+++ b/src/helpers/url.ts
@@ -1,0 +1,9 @@
+const isValidUrl = (url: string) => {
+  try {
+    return Boolean(new URL(url));
+  } catch (e) {
+    return false;
+  }
+};
+
+export { isValidUrl };

--- a/src/lib/post.ts
+++ b/src/lib/post.ts
@@ -4,8 +4,9 @@ import { join } from 'path';
 import matter from 'gray-matter';
 
 type Author = {
-  name: string;
-  avatar: string;
+  name?: string;
+  avatarUrl?: string;
+  username?: string;
 };
 
 type Post = {
@@ -120,4 +121,4 @@ export {
   randomPostSlug,
   POST_FIELDS,
 };
-export type { Post, Field };
+export type { Post, Field, Author };


### PR DESCRIPTION
Resolves https://github.com/nimblehq/til-web/issues/37

## What happened 👀

- Add a helper to get the avatar URL from GitHub instead of uploading it to this repository and showing it
- Modify components to use this helper

## Insight 📝

The avatar link is got from https://stackoverflow.com/a/36380674/6339862

## Proof Of Work 📹

- Tests should be passed
- Avatars are still displayed on the preview link
